### PR TITLE
check-kernel-version: a small script for re-installing QAT driver.

### DIFF
--- a/check-kernel-version/README.md
+++ b/check-kernel-version/README.md
@@ -1,0 +1,26 @@
+# Automatically re-install out-of-tree QAT driver
+
+Updating the kernel without updating the out-of-tree QAT driver can lead
+to incorrect behavior when the in-tree QAT driver tries to load the
+firmware blobs. QAT driver doesn't yet have DKMS support implemented. As
+a workaround, we offer a script for checking if the out-of-tree driver
+is not used during system startup and re-installing the driver.
+
+# Install and configure the script
+
+Copy the script, the service file and the configuration file in place:
+
+    # install -d /etc/systemd/system/check-qat-kernel.service.d
+    # install -d /usr/local/bin
+    # install check-qat-kernel.sh /usr/local/bin/
+    # install check-qat-kernel.service /etc/systemd/system/
+    # install check-qat-kernel.conf /etc/systemd/system/check-qat-kernel.service.d/
+
+Edit the configuration file
+`/etc/systemd/system/check-qat-kernel.service.d/check-qat-kernel.conf` to point
+the `QAT_DRIVER_FILE` environment variable to the location of the QAT
+driver archive in your system.
+
+Enable the service file:
+
+    # systemctl enable check-qat-kernel.service

--- a/check-kernel-version/check-qat-kernel.conf
+++ b/check-kernel-version/check-qat-kernel.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="QAT_DRIVER_FILE=/root/qat1.7.l.4.3.0-00033.tar.gz"

--- a/check-kernel-version/check-qat-kernel.service
+++ b/check-kernel-version/check-qat-kernel.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Service for updating the out-of-tree QAT driver after a kernel update.
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/check-qat-kernel.sh
+PrivateTmp=yes
+Before=kubelet.service
+
+[Install]
+WantedBy=multi-user.target

--- a/check-kernel-version/check-qat-kernel.sh
+++ b/check-kernel-version/check-qat-kernel.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+MODULE_NAME=$(modinfo -n intel_qat)
+
+if echo "$MODULE_NAME" | grep -q updates; then
+    echo "Properly using the out-of-tree kernel driver."
+    exit 0
+fi
+
+# Re-install QAT driver.
+
+if [ ! -f "$QAT_DRIVER_FILE" ]; then
+    echo "No QAT driver file found."
+    exit 1
+fi
+
+BUILD_DIR=$(mktemp -d /tmp/qat-build-dir.XXXXXXXX)
+cd "$BUILD_DIR"
+tar xzvf "$QAT_DRIVER_FILE"
+./configure --enable-qat-uio
+make -j8
+make install
+
+# Using systemd PrivateTmp, cleanup is done automatically.


### PR DESCRIPTION
Check if the QAT driver has been compiled against the current kernel. Re-install the driver if not.