### PR TITLE
Fixing Clearlinux support with Envoy+OpenSSL

### DIFF
--- a/Dockerfile.clr.envoy
+++ b/Dockerfile.clr.envoy
@@ -7,7 +7,10 @@ ADD envoy envoy
 
 # Add bundles and deps
 RUN rm -rf /run/lock/clrtrust.lock
-RUN clrtrust generate && swupd update && swupd bundle-add os-core-dev
+RUN clrtrust generate
+# Support envoy build, returning to latest version of clearlinux with gcc version 8.x.x
+RUN swupd verify --fix -m 28970 --force
+RUN swupd bundle-add os-core-dev --skip-diskspace-check
 RUN curl -LO https://github.com/bazelbuild/bazel/releases/download/0.19.2/bazel-0.19.2-installer-linux-x86_64.sh && \
     chmod +x bazel-0.19.2-installer-linux-x86_64.sh && \
     ./bazel-0.19.2-installer-linux-x86_64.sh --user


### PR DESCRIPTION
This patch, force the latest clearlinux:base image to update swupd to,
latest version which installs gcc-8.x.x, since the envoy build fails when,
is built with gcc-9.x.x;

Signed-off-by: Rivera Gonzalez, Julio C <julio.c.rivera.gonzalez@intel.com>