### PR TITLE
QAT_Engine: switch to upstream version v0.5.41.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = openssl-container
 [submodule "QAT_Engine"]
 	path = QAT_Engine
-	url = https://github.com/ipuustin/QAT_Engine.git
-	branch = section_name_env
+	url = https://github.com/intel/QAT_Engine.git
+	branch = master
 [submodule "intel-device-plugins-for-kubernetes"]
 	path = intel-device-plugins-for-kubernetes
 	url = https://github.com/intel/intel-device-plugins-for-kubernetes.git


### PR DESCRIPTION
The patches we carried were merged in upstream master branch. Start to follow real upstream and not the forked version.