### PR TITLE
vagrant: enable Intel IOMMU to support QAT pass-through

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -90,6 +90,14 @@ Vagrant.configure("2") do |config|
     v.management_network_address = "192.168.123.0/27"
     v.management_network_name = "qat-mgmt-net"
     v.random_hostname = true
+    # Intel Corporation QuickAssist Technology
+    qat_devices = `for i in 0434 0435 37c8 6f54 19e2; do lspci -d 8086:$i -m; done|awk '{print $1}'`
+    qat_devices.split("\n").each do |dev|
+      bus=dev.split(':')[0]
+      slot=dev.split(':')[1].split('.')[0]
+      function=dev.split(':')[1].split('.')[1]
+      v.pci :bus => "0x#{bus}", :slot => "0x#{slot}", :function => "0x#{function}"
+    end
   end
 
   if ENV['http_proxy'] != nil and ENV['https_proxy'] != nil


### PR DESCRIPTION
Enable Intel IOMMU if it not enable, it's needed to support QAT pass-through
in virtual machines

Signed-off-by: Julio Montes <julio.montes@intel.com>