### PR TITLE
Disable Persistent storage for InfluxDB Helm Chart

### DIFF
--- a/vagrant/influxdb_values.yml
+++ b/vagrant/influxdb_values.yml
@@ -25,3 +25,6 @@ env:
     value: "grafana"
   - name: INFLUXDB_READ_USER_PASSWORD
     value: "secret"
+
+persistence:
+  enabled: false


### PR DESCRIPTION
The default value for persistence in the InfluxDB Helm chart has been [changed](https://github.com/helm/charts/commit/802588ac170bb03446bdf933a6c7e7eb09b31baf) to *true*[1]. Given that this feature is not required this change ensures that is disabled.