### PR TITLE
build: make builds with git submodules more robust

### DIFF
--- a/Dockerfile.clr.envoy
+++ b/Dockerfile.clr.envoy
@@ -1,11 +1,9 @@
 FROM clearlinux:base as builder
 
-ADD envoy-openssl envoy-openssl
-ADD envoy-openssl.WORKSPACE envoy-openssl/WORKSPACE
-RUN rm -rf envoy-openssl/envoy
-ADD envoy envoy-openssl/envoy
-ADD scripts scripts
-ADD versions.yaml versions.yaml
+COPY . .
+RUN mv envoy-openssl.WORKSPACE envoy-openssl/WORKSPACE && \
+    rm -rf envoy-openssl/envoy && \
+    mv envoy envoy-openssl/envoy
 
 RUN bash -f scripts/build_qat_envoy.sh
 

--- a/Dockerfile.envoy
+++ b/Dockerfile.envoy
@@ -1,11 +1,9 @@
 FROM debian:sid as builder
 
-ADD envoy-openssl envoy-openssl
-ADD envoy-openssl.WORKSPACE envoy-openssl/WORKSPACE
-RUN rm -rf envoy-openssl/envoy
-ADD envoy envoy-openssl/envoy
-ADD scripts scripts
-ADD versions.yaml versions.yaml
+COPY . .
+RUN mv envoy-openssl.WORKSPACE envoy-openssl/WORKSPACE && \
+    rm -rf envoy-openssl/envoy && \
+    mv envoy envoy-openssl/envoy
 
 RUN bash -f scripts/build_qat_envoy.sh
 

--- a/scripts/build_qat_envoy.sh
+++ b/scripts/build_qat_envoy.sh
@@ -56,7 +56,7 @@ setup() {
 			rm -rf /run/lock/clrtrust.lock
 			clrtrust generate
 			swupd update
-			swupd bundle-add os-core-dev
+			swupd bundle-add os-core-dev python2-basic
 			;;
 		debian|ubuntu)
 			info "Debian/Ubuntu OS detected"
@@ -196,12 +196,8 @@ build_install_qat_engine() {
 build_envoy() {
 	pushd "${ENVOY_DIR}"
 	case $ID in
-		clear-linux*)
-		    CXXFLAGS="-Wno-error=stringop-truncation -Wno-error=redundant-move -DENVOY_SSL_VERSION=\\\"OpenSSL\\\"" ~/.bazel/bin/bazel build -j "$(jobs)" -c opt //:envoy --define boringssl=disabled
-		    ;;
-
-		debian|ubuntu)
-		    CXXFLAGS="-Wno-error=stringop-truncation -Wno-error=redundant-move -DENVOY_SSL_VERSION=\\\"OpenSSL\\\"" ~/.bazel/bin/bazel build -j "$(jobs)" -c opt //:envoy --define boringssl=disabled
+		clear-linux*|debian|ubuntu)
+		    CXXFLAGS="-DENVOY_SSL_VERSION=\\\"OpenSSL\\\"" ~/.bazel/bin/bazel build -j "$(jobs)" -c opt //:envoy --define boringssl=disabled
 		    ;;
 	esac
 	popd


### PR DESCRIPTION
Some git versions make the submodules' .git directories
pointing to superproject's .git/modules/<submodule> resulting
in failures with some Bazel rules:

fatal: not a git repository: /envoy-openssl/../.git/modules/envoy-openssl

Copy the whole superproject git repository in the build container to
ensure the paths are preserved.

Finally, drop the special CXXFLAGS that were needed to get builds
passing with GCC 9. Envoy has the build failures now fixed.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>