### PR TITLE
Update the BoringSSL QAT provider tree to latest.

### DIFF
--- a/Dockerfile.clr.boringssl.envoy
+++ b/Dockerfile.clr.boringssl.envoy
@@ -24,20 +24,20 @@ RUN mkdir /install_root \
     --no-boot-update \
     && rm -rf /install_root/var/lib/swupd/*
 
-RUN swupd bundle-add os-core-dev c-basic python2-basic
+RUN swupd bundle-add os-core-dev c-basic python-basic
 
 # for installing bazel as user
 ENV HOME /root
 
 # bazel 1.1 is not packaged to Clear Linux yet, change to that bundle when it is
-RUN curl -LO https://github.com/bazelbuild/bazel/releases/download/1.1.0/bazel-1.1.0-installer-linux-x86_64.sh
-RUN chmod +x bazel-1.1.0-installer-linux-x86_64.sh
-RUN ./bazel-1.1.0-installer-linux-x86_64.sh --user
+RUN curl -LO https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel-2.0.0-installer-linux-x86_64.sh
+RUN chmod +x bazel-2.0.0-installer-linux-x86_64.sh
+RUN ./bazel-2.0.0-installer-linux-x86_64.sh --user
 
-RUN git clone --recurse-submodules --single-branch --branch qat-provider-master https://github.com/ipuustin/envoy.git envoy
+RUN git clone --recurse-submodules --single-branch --branch v1.13.0-qat4 https://github.com/ipuustin/envoy.git envoy
 
 # build and install Envoy
-RUN cd envoy && /root/.bazel/bin/bazel build --verbose_failures -c opt -s //source/exe:envoy-static \
+RUN cd envoy && /root/.bazel/bin/bazel build --verbose_failures -c opt -s //source/exe:envoy-static --extra_toolchains=@rules_python//python:autodetecting_toolchain_nonstrict \
     && install -D /envoy/LICENSE /install_root/usr/local/share/package-licenses/envoy/LICENSE \
     && install -D /envoy/bazel-bin/source/exe/envoy-static /install_root/usr/local/bin/envoy-static
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ systemReserved:
   memory: 256M
 kubeReserved:
   cpu: 500m
-memory: 256M
+  memory: 256M
 ...
 ```
 

--- a/deployments/boringssl-envoy-deployment.yaml
+++ b/deployments/boringssl-envoy-deployment.yaml
@@ -39,7 +39,7 @@ data:
                 private_key_provider:
                   provider_name: qat
                   typed_config:
-                    "@type": "type.googleapis.com/qat.QatPrivateKeyMethodConfig"
+                    "@type": "type.googleapis.com/envoy.extensions.private_key_providers.qat.v3.QatPrivateKeyMethodConfig"
                     section_name: ${QAT_SECTION_NAME}
                     poll_delay: ${POLL_DELAY}
                     private_key: "/etc/envoy/tls/tls.key"

--- a/examples/boringssl-envoy-conf.yaml
+++ b/examples/boringssl-envoy-conf.yaml
@@ -12,7 +12,7 @@ static_resources:
             private_key_provider:
               provider_name: qat
               typed_config:
-                "@type": "type.googleapis.com/qat.QatPrivateKeyMethodConfig"
+                "@type": "type.googleapis.com/envoy.extensions.private_key_providers.qat.v3.QatPrivateKeyMethodConfig"
                 section_name: ${QAT_SECTION_NAME}
                 poll_delay: ${POLL_DELAY}
                 private_key: "/etc/envoy/tls/tls.key"


### PR DESCRIPTION
The biggest change is moving to use verson-managed API objects in Envoy. Also start using tags for version management. Do not use Python 2 in Bazel - the compilation succeeds with Python 3. Fix a trivial problem in the README.