### PR TITLE
images: optimize Dockefile.openssl further

### DIFF
--- a/Dockerfile.openssl
+++ b/Dockerfile.openssl
@@ -28,28 +28,7 @@ RUN sed -i -e 's/cmn_ko$//' -e 's/lac_kernel$//' quickassist/Makefile && \
     make quickassist-all adf-ctl-all && \
     install -m 755 build/libqat_s.so /usr/lib/ && \
     install -m 755 build/libusdm_drv_s.so /usr/lib/ && \
-    install -m 755 build/adf_ctl /usr/bin/ && \
-    cd /ipp-crypto/sources/ippcp/crypto_mb && \
-    sed -i -e '/OPENSSL_USE_STATIC_LIBS/d' CMakeLists.txt && \
-    cmake . -B"../build" \
-    -DOPENSSL_INCLUDE_DIR=/usr/include/openssl \
-    -DOPENSSL_LIBRARIES=/usr/lib64 \
-    -DOPENSSL_ROOT_DIR=/usr/bin/openssl && \
-    cd ../build && \
-    make crypto_mb && make install && \
-    install -m 755 bin/vfy_ifma_cp_rsa_mb /usr/bin/ && \
-    install -m 755 bin/vfy_ifma_rsa_mb /usr/bin/ && \
-    cd /QAT_Engine && \
-    ./autogen.sh && \
-    ./configure \
-    $QAT_ENGINE_FLAGS \
-    --with-qat_dir=/QAT_Lib \
-    --with-openssl_install_dir=/usr/lib64 \
-    --with-qat_install_dir=/usr/lib \
-    --with-multibuff_dir=/ipp-crypto/sources/ippcp/crypto_mb \
-    --with-multibuff_install_dir=/usr/local/lib \
-    --enable-openssl_install_build_arch_path && \
-    make && make install
+    install -m 755 build/adf_ctl /usr/bin/
 
 WORKDIR /
 
@@ -62,7 +41,34 @@ RUN eval $(cut -d = -f 2- < clang.bazelrc) && \
 RUN curl -LO https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel-2.0.0-installer-linux-x86_64.sh && \
     chmod +x bazel-2.0.0-installer-linux-x86_64.sh && \
     ./bazel-2.0.0-installer-linux-x86_64.sh --user
-RUN /root/.bazel/bin/bazel build -c opt //:envoy --host_force_python=PY3
+
+ARG BAZEL_EXTRA_BUILD_ARGS=
+
+RUN /root/.bazel/bin/bazel build -c opt $BAZEL_EXTRA_BUILD_ARGS //:envoy --host_force_python=PY3
+
+WORKDIR /ipp-crypto/sources/ippcp/crypto_mb
+
+RUN sed -i -e '/OPENSSL_USE_STATIC_LIBS/d' CMakeLists.txt && \
+    cmake . -B"../build" \
+    -DOPENSSL_INCLUDE_DIR=/usr/include/openssl \
+    -DOPENSSL_LIBRARIES=/usr/lib64 \
+    -DOPENSSL_ROOT_DIR=/usr/bin/openssl && \
+    cd ../build && \
+    make crypto_mb && make install && \
+    install -m 755 bin/vfy_ifma_cp_rsa_mb /usr/bin/ && \
+    install -m 755 bin/vfy_ifma_rsa_mb /usr/bin/
+
+WORKDIR /QAT_Engine
+RUN ./autogen.sh && \
+    ./configure \
+    $QAT_ENGINE_FLAGS \
+    --with-qat_dir=/QAT_Lib \
+    --with-openssl_install_dir=/usr/lib64 \
+    --with-qat_install_dir=/usr/lib \
+    --with-multibuff_dir=/ipp-crypto/sources/ippcp/crypto_mb \
+    --with-multibuff_install_dir=/usr/local/lib \
+    --enable-openssl_install_build_arch_path && \
+    make && make install
 
 FROM clearlinux:base
 


### PR DESCRIPTION
By splitting the build stages so that ipp-crypto/QAT Engine
are built after Envoy and also separate from each other we
get to re-use cached stages even more (for instance, when
testing QAT Engine with some new configure options, we don't need
to rebuild Envoy).

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>