### PR TITLE
QATzip fixes

### DIFF
--- a/envoy_qatzip/BUILD
+++ b/envoy_qatzip/BUILD
@@ -34,6 +34,7 @@ envoy_cc_library(
     deps = [
         ":pkg_cc_proto",
         "//envoy_qatzip/compressor:qatzip_compressor_lib",
+        "@envoy//include/envoy/thread_local:thread_local_interface",
         "@envoy//source/extensions/filters/http:well_known_names",
         "@envoy//source/extensions/filters/http/common:factory_base_lib",
         "@envoy//source/extensions/filters/http/common/compressor:compressor_lib",

--- a/envoy_qatzip/compressor/qatzip_compressor_impl.cc
+++ b/envoy_qatzip/compressor/qatzip_compressor_impl.cc
@@ -9,43 +9,18 @@
 namespace Envoy {
 namespace Compressor {
 
-QatzipCompressorImpl::QatzipCompressorImpl() : QatzipCompressorImpl(4096) {}
+QatzipCompressorImpl::QatzipCompressorImpl(QzSession_T* session)
+    : QatzipCompressorImpl(session, 4096) {}
 
-QatzipCompressorImpl::QatzipCompressorImpl(size_t chunk_size)
-    : initialized_{false}, chunk_size_{chunk_size}, avail_out_{chunk_size},
-      chunk_char_ptr_(new unsigned char[chunk_size]), session_{}, stream_{} {
+QatzipCompressorImpl::QatzipCompressorImpl(QzSession_T* session, size_t chunk_size)
+    : chunk_size_{chunk_size}, avail_out_{chunk_size},
+      chunk_char_ptr_(new unsigned char[chunk_size]), session_{session}, stream_{} {
+  RELEASE_ASSERT(session_ != nullptr,
+                 "QATzip compressor must be created with non-null QATzip session");
   stream_.out = chunk_char_ptr_.get();
 }
 
-QatzipCompressorImpl::~QatzipCompressorImpl() {
-  if (initialized_) {
-    qzEndStream(&session_, &stream_);
-    qzTeardownSession(&session_);
-    qzClose(&session_);
-  }
-}
-
-void QatzipCompressorImpl::init(unsigned int compression_level, unsigned int hardware_buffer_size,
-                                unsigned int stream_buffer_size,
-                                unsigned int input_size_threshold) {
-  QzSessionParams_T params;
-
-  ASSERT(initialized_ == false);
-
-  int status = qzGetDefaults(&params);
-  RELEASE_ASSERT(status == QZ_OK, "failed to initialize hardware");
-  params.comp_lvl = compression_level;
-  params.hw_buff_sz = hardware_buffer_size;
-  params.strm_buff_sz = stream_buffer_size;
-  params.input_sz_thrshold = input_size_threshold;
-
-  status = qzInit(&session_, params.sw_backup);
-  RELEASE_ASSERT(status == QZ_OK || status == QZ_DUPLICATE, "failed to initialize hardware");
-  status = qzSetupSession(&session_, &params);
-  RELEASE_ASSERT(status == QZ_OK || status == QZ_DUPLICATE, "failed to setup session");
-
-  initialized_ = true;
-}
+QatzipCompressorImpl::~QatzipCompressorImpl() { qzEndStream(session_, &stream_); }
 
 void QatzipCompressorImpl::compress(Buffer::Instance& buffer, State state) {
 
@@ -79,7 +54,7 @@ void QatzipCompressorImpl::compress(Buffer::Instance& buffer, State state) {
 void QatzipCompressorImpl::process(Buffer::Instance& output_buffer, unsigned int last) {
   stream_.in_sz = avail_in_;
   stream_.out_sz = avail_out_;
-  auto status = qzCompressStream(&session_, &stream_, last);
+  auto status = qzCompressStream(session_, &stream_, last);
   // NOTE: stream_.in_sz and stream_.out_sz have changed their semantics after the call
   //       to qzCompressStream(). Despite their name the new values are consumed input
   //       and produced output (not available buffer sizes).

--- a/envoy_qatzip/compressor/qatzip_compressor_impl.cc
+++ b/envoy_qatzip/compressor/qatzip_compressor_impl.cc
@@ -12,12 +12,15 @@ namespace Compressor {
 QatzipCompressorImpl::QatzipCompressorImpl(QzSession_T* session)
     : QatzipCompressorImpl(session, 4096) {}
 
+// TODO(rojkov): add lower limit to chunk_size in proto definition.
 QatzipCompressorImpl::QatzipCompressorImpl(QzSession_T* session, size_t chunk_size)
-    : chunk_size_{chunk_size}, avail_out_{chunk_size},
-      chunk_char_ptr_(new unsigned char[chunk_size]), session_{session}, stream_{} {
+    : chunk_size_{chunk_size}, avail_out_{chunk_size-10},
+      chunk_char_ptr_(new unsigned char[chunk_size]), session_{session}, stream_{}, input_len_(0),
+      trailer_(new unsigned char[8]) {
   RELEASE_ASSERT(session_ != nullptr,
                  "QATzip compressor must be created with non-null QATzip session");
-  stream_.out = chunk_char_ptr_.get();
+  static unsigned char gzheader[10] = { 0x1f, 0x8b, 8, 0, 0, 0, 0, 0, 0, 3 };
+  stream_.out = static_cast<unsigned char*>(mempcpy(chunk_char_ptr_.get(), gzheader, 10));
 }
 
 QatzipCompressorImpl::~QatzipCompressorImpl() { qzEndStream(session_, &stream_); }
@@ -48,6 +51,17 @@ void QatzipCompressorImpl::compress(Buffer::Instance& buffer, State state) {
     if (n_output > 0) {
       buffer.add(static_cast<void*>(chunk_char_ptr_.get()), n_output);
     }
+
+    trailer_[0] = static_cast<unsigned char>((stream_.crc_32 >> 0) & 0xff);
+    trailer_[1] = static_cast<unsigned char>((stream_.crc_32 >> 8) & 0xff);
+    trailer_[2] = static_cast<unsigned char>((stream_.crc_32 >> 16) & 0xff);
+    trailer_[3] = static_cast<unsigned char>((stream_.crc_32 >> 24) & 0xff);
+
+    trailer_[4] = static_cast<unsigned char>((input_len_ >> 0) & 0xff);
+    trailer_[5] = static_cast<unsigned char>((input_len_ >> 8) & 0xff);
+    trailer_[6] = static_cast<unsigned char>((input_len_ >> 16) & 0xff);
+    trailer_[7] = static_cast<unsigned char>((input_len_ >> 24) & 0xff);
+    buffer.add(static_cast<void*>(trailer_.get()), 8);
   }
 }
 
@@ -60,6 +74,7 @@ void QatzipCompressorImpl::process(Buffer::Instance& output_buffer, unsigned int
   //       and produced output (not available buffer sizes).
   avail_out_ -= stream_.out_sz;
   avail_in_ -= stream_.in_sz;
+  input_len_ += stream_.in_sz;
   stream_.in = stream_.in + stream_.in_sz;
   stream_.out = stream_.out + stream_.out_sz;
   RELEASE_ASSERT(status == QZ_OK, "");

--- a/envoy_qatzip/compressor/qatzip_compressor_impl.h
+++ b/envoy_qatzip/compressor/qatzip_compressor_impl.h
@@ -36,6 +36,9 @@ private:
   std::unique_ptr<unsigned char[]> chunk_char_ptr_;
   QzSession_T* const session_;
   QzStream_T stream_;
+
+  uint32_t input_len_;
+  std::unique_ptr<unsigned char[]> trailer_;
 };
 
 } // namespace Compressor

--- a/envoy_qatzip/compressor/qatzip_compressor_impl.h
+++ b/envoy_qatzip/compressor/qatzip_compressor_impl.h
@@ -12,7 +12,7 @@ namespace Compressor {
  */
 class QatzipCompressorImpl : public Compressor {
 public:
-  QatzipCompressorImpl();
+  QatzipCompressorImpl(QzSession_T* session);
 
   /**
    * Constructor that allows setting the size of compressor's output buffer. It
@@ -20,15 +20,8 @@ public:
    * default constructor, is desired.
    * @param chunk_size amount of memory reserved for the compressor output.
    */
-  QatzipCompressorImpl(size_t chunk_size);
+  QatzipCompressorImpl(QzSession_T* session, size_t chunk_size);
   virtual ~QatzipCompressorImpl();
-
-  /**
-   * Init must be called in order to initialize the compressor. Once compressor is initialized, it
-   * cannot be initialized again. Init should run before compressing any data.
-   */
-  void init(unsigned int compression_level, unsigned int hardware_buffer_size,
-            unsigned int stream_buffer_size, unsigned int input_size_threshold);
 
   // Compressor
   void compress(Buffer::Instance& buffer, State state) override;
@@ -36,13 +29,12 @@ public:
 private:
   void process(Buffer::Instance& output_buffer, unsigned int last);
 
-  bool initialized_;
   const size_t chunk_size_;
   size_t avail_in_;
   size_t avail_out_;
 
   std::unique_ptr<unsigned char[]> chunk_char_ptr_;
-  QzSession_T session_;
+  QzSession_T* const session_;
   QzStream_T stream_;
 };
 

--- a/envoy_qatzip/config.cc
+++ b/envoy_qatzip/config.cc
@@ -12,7 +12,7 @@ Http::FilterFactoryCb QatzipFilterFactory::createFilterFactoryFromProtoTyped(
     Server::Configuration::FactoryContext& context) {
   Common::Compressors::CompressorFilterConfigSharedPtr config =
       std::make_shared<QatzipFilterConfig>(proto_config, stats_prefix, context.scope(),
-                                           context.runtime());
+                                           context.runtime(), context.threadLocal());
   return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<Common::Compressors::CompressorFilter>(config));
   };

--- a/envoy_qatzip/qatzip_filter.cc
+++ b/envoy_qatzip/qatzip_filter.cc
@@ -25,6 +25,7 @@ QatzipFilterConfig::QatzipFilterConfig(const qatzip::Qatzip& qatzip,
   params.hw_buff_sz = hardwareBufferSizeEnum(qatzip.hardware_buffer_size());
   params.strm_buff_sz = streamBufferSizeUint(qatzip.stream_buffer_size().value());
   params.input_sz_thrshold = inputSizeThresholdUint(qatzip.input_size_threshold().value());
+  params.data_fmt = QZ_DEFLATE_RAW;
 
   tls_slot_->set([params](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
     return std::make_shared<QatzipThreadLocal>(params);


### PR DESCRIPTION
1. Create one QATzip session per worker thread.

2. Do not rely on QATzip for wrapping compressed streams with correct headers and trailers. Instead set up QATzip to disable this wrapping with ```params.data_fmt = QZ_DEFLATE_RAW;``` (anyway it wraps not stream, but  every output buffer) and wrap the stream right in the filter instead. This way in-browser decompression should work.
