### PR TITLE
Update BoringSSL+QAT to latest Envoy version.

### DIFF
--- a/Dockerfile.boringssl
+++ b/Dockerfile.boringssl
@@ -29,15 +29,15 @@ RUN swupd bundle-add os-core-dev c-basic python3-basic
 # for installing bazel as user
 ENV HOME /root
 
-# bazel 1.1 is not packaged to Clear Linux yet, change to that bundle when it is
-RUN curl -LO https://github.com/bazelbuild/bazel/releases/download/2.0.0/bazel-2.0.0-installer-linux-x86_64.sh
-RUN chmod +x bazel-2.0.0-installer-linux-x86_64.sh
-RUN ./bazel-2.0.0-installer-linux-x86_64.sh --user
+# bazel 3.4 is not packaged to Clear Linux yet, change to that bundle when it is
+RUN curl -LO https://github.com/bazelbuild/bazel/releases/download/3.4.1/bazel-3.4.1-installer-linux-x86_64.sh
+RUN chmod +x bazel-3.4.1-installer-linux-x86_64.sh
+RUN ./bazel-3.4.1-installer-linux-x86_64.sh --user
 
-RUN git clone --recurse-submodules --single-branch --branch v1.13.0-qat4 https://github.com/ipuustin/envoy.git envoy
+RUN git clone --recurse-submodules --single-branch --branch v1.15.0-qat1 https://github.com/ipuustin/envoy.git envoy
 
 # build and install Envoy
-RUN cd envoy && /root/.bazel/bin/bazel build --verbose_failures -c opt -s //source/exe:envoy-static --extra_toolchains=@rules_python//python:autodetecting_toolchain_nonstrict \
+RUN cd envoy && /root/.bazel/bin/bazel build --copt="-Wno-uninitialized" --copt="-Wno-maybe-uninitialized" --copt="-Wno-stringop-truncation" --verbose_failures -c opt -s //source/exe:envoy-static --extra_toolchains=@rules_python//python:autodetecting_toolchain_nonstrict \
     && install -D /envoy/LICENSE /install_root/usr/local/share/package-licenses/envoy/LICENSE \
     && install -D /envoy/bazel-bin/source/exe/envoy-static /install_root/usr/local/bin/envoy-static
 

--- a/examples/boringssl-envoy-conf.yaml
+++ b/examples/boringssl-envoy-conf.yaml
@@ -12,7 +12,7 @@ static_resources:
             private_key_provider:
               provider_name: qat
               typed_config:
-                "@type": "type.googleapis.com/envoy.extensions.private_key_providers.qat.v3.QatPrivateKeyMethodConfig"
+                "@type": "type.googleapis.com/envoy.extensions.private_key_operations_providers.qat.v3.QatPrivateKeyMethodConfig"
                 section_name: ${QAT_SECTION_NAME}
                 poll_delay: ${POLL_DELAY}
                 private_key: "/etc/envoy/tls/tls.key"

--- a/scripts/envoy-boringssl-docker.sh
+++ b/scripts/envoy-boringssl-docker.sh
@@ -28,4 +28,4 @@ if [[ ! -f "${BASE_DIR}"/cert.pem || ! -f "${BASE_DIR}"/key.pem ]]; then
   openssl req -x509 -new -batch -nodes -subj '/CN=localhost' -keyout "${BASE_DIR}"/key.pem -out "${BASE_DIR}"/cert.pem
 fi
 
-docker run --rm -ti -p 9000:9000 $CPUSET_PARAM --security-opt seccomp=unconfined --security-opt apparmor=unconfined $DEVS_PARAM --cap-add=SYS_ADMIN --cap-add=IPC_LOCK -v "${BASE_DIR}"/cert.pem:/etc/envoy/tls/tls.crt -v "${BASE_DIR}"/key.pem:/etc/envoy/tls/tls.key -v $CONFIG_FILE_PARAM:/etc/envoy/config/envoy-conf.yaml envoy-boringssl-qat:devel --cpuset-threads
+docker run --rm -ti -p 9000:9000 $CPUSET_PARAM --security-opt seccomp=unconfined --security-opt apparmor=unconfined $DEVS_PARAM --cap-add=SYS_ADMIN --cap-add=IPC_LOCK -v "${BASE_DIR}"/cert.pem:/etc/envoy/tls/tls.crt -v "${BASE_DIR}"/key.pem:/etc/envoy/tls/tls.key -v $CONFIG_FILE_PARAM:/etc/envoy/config/envoy-conf.yaml -v /dev/hugepages/qat:/dev/hugepages/qat envoy-boringssl-qat:devel --cpuset-threads


### PR DESCRIPTION
Update to Envoy 1.15. Also update QAT to 4.10. Fix (or rather work around) gcc build issues. Better code and protobuf file formatting.