### PR TITLE
Dockerfile.openssl: fix ipp-crypto build

### DIFF
--- a/Dockerfile.openssl
+++ b/Dockerfile.openssl
@@ -3,6 +3,7 @@ FROM clearlinux:base as builder
 ARG QAT_DRIVER_RELEASE="qat1.7.l.4.10.0-00014"
 ARG QAT_ENGINE_VERSION="v0.5.46"
 ARG IPSEC_MB_VERSION="v0.54"
+ARG IPP_CRYPTO_VERSION="ippcp_2020u2"
 
 RUN swupd update && \
     swupd bundle-add \
@@ -17,7 +18,7 @@ RUN swupd update && \
     python3-basic \
     os-core-dev && \
     git clone -b $QAT_ENGINE_VERSION https://github.com/intel/QAT_Engine && \
-    git clone https://github.com/intel/ipp-crypto && \
+    git clone -b $IPP_CRYPTO_VERSION https://github.com/intel/ipp-crypto && \
     git clone -b $IPSEC_MB_VERSION https://github.com/intel/intel-ipsec-mb && \
     mkdir QAT_Lib && cd QAT_Lib && \
     curl -L https://01.org/sites/default/files/downloads/$QAT_DRIVER_RELEASE.tar.gz | tar zx


### PR DESCRIPTION
ipp-crypto repository did not provide a tag with the necessary changes
included until recently so we were using the master branch.

Now the tag was added (and master broke our build) so we move to use it.

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>