### PR TITLE
Use qat-hw by default OpenSSL engine id

### DIFF
--- a/deployments/nginx-behind-envoy-deployment.yaml
+++ b/deployments/nginx-behind-envoy-deployment.yaml
@@ -73,7 +73,7 @@ data:
     [ engine_section ]
     qat = qat_section
     [ qat_section ]
-    engine_id = qat
+    engine_id = qat-hw # Change "qat-hw" into "qat-sw" if you want to benefit from CPU acceleration.
     default_algorithms = ALL
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
In the envoy-qat container, the "qat-hw" and "qat-sw" engine ids are generated
rather than the "qat" engine id. And, use the "qat-hw" engine id by
default.