### PR TITLE
Update Dockerfile and configuration files.

### DIFF
--- a/Dockerfile.boringssl
+++ b/Dockerfile.boringssl
@@ -1,60 +1,30 @@
-# CLEAR_LINUX_BASE and CLEAR_LINUX_VERSION can be used to make the build
-# reproducible by choosing an image by its hash and installing an OS version
-# with --version=:
-# CLEAR_LINUX_BASE=clearlinux@sha256:b8e5d3b2576eb6d868f8d52e401f678c873264d349e469637f98ee2adf7b33d4
-# CLEAR_LINUX_VERSION="--version=29970"
-#
-# This is used on release branches before tagging a stable version.
-ARG CLEAR_LINUX_BASE=clearlinux:base
+FROM envoyproxy/envoy-build-ubuntu:514e2f7bc36c1f0495a523b16aab9168a4aa13b6 as builder
 
-FROM ${CLEAR_LINUX_BASE} as builder
+RUN git clone --single-branch --branch qat-provider-main-oot-v6 https://github.com/ipuustin/envoy.git envoy
 
-ARG CLEAR_LINUX_VERSION=
+WORKDIR /envoy
 
-# try twice to work around a swupd bug
-RUN swupd update --no-boot-update ${CLEAR_LINUX_VERSION} || swupd update --no-boot-update ${CLEAR_LINUX_VERSION}
+RUN apt-get update && apt-get install -y gettext yasm
 
-RUN mkdir /install_root \
-    && swupd os-install \
-    ${CLEAR_LINUX_VERSION} \
-    --path /install_root \
-    --statedir /swupd-state \
-    --bundles=os-core,libstdcpp \
-    --no-boot-update \
-    && rm -rf /install_root/var/lib/swupd/*
+RUN bazel build --copt="-mcx16" --cxxopt="-mcx16" -c opt //contrib/exe:envoy-static --//contrib/vcl/source:enabled=false
 
-# GCC11 does not work with Envoy and we need to use GCC10.
-RUN swupd bundle-add os-core-dev c-extras-gcc10 python3-basic
-
-# for installing bazel as user
-ENV HOME /root
-
-# bazel 3.4 is not packaged to Clear Linux yet, change to that bundle when it is
-RUN curl -LO https://github.com/bazelbuild/bazel/releases/download/4.1.0/bazel-4.1.0-installer-linux-x86_64.sh
-RUN chmod +x bazel-4.1.0-installer-linux-x86_64.sh
-RUN ./bazel-4.1.0-installer-linux-x86_64.sh --user
-
-RUN git clone --recurse-submodules --single-branch --branch qat-provider-main-v5 https://github.com/ipuustin/envoy.git envoy
-
-# build and install Envoy
-RUN cd envoy && CC=gcc-10 CXX=g++-10 /root/.bazel/bin/bazel build --copt="-Wno-uninitialized" --copt="-Wno-maybe-uninitialized" --copt="-Wno-stringop-truncation" --verbose_failures -c opt -s //source/exe:envoy-static --extra_toolchains=@rules_python//python:autodetecting_toolchain_nonstrict \
-    && install -D /envoy/LICENSE /install_root/usr/local/share/package-licenses/envoy/LICENSE \
-    && install -D /envoy/bazel-bin/source/exe/envoy-static /install_root/usr/local/bin/envoy-static
+RUN install -D /envoy/LICENSE /tmp/install_root/usr/local/share/package-licenses/envoy/LICENSE
+RUN install -D /envoy/bazel-bin/contrib/exe/envoy-static /tmp/install_root/usr/local/bin/envoy-static
 
 # generate entrypoint script
-RUN echo -e "#!/bin/sh\n" \
-            "set -e\n" \
-            "/usr/bin/envsubst < /etc/envoy/config/envoy-conf.yaml > /tmp/envoy-conf.yaml\n" \
-            "/usr/local/bin/envoy-static -c /tmp/envoy-conf.yaml \$@\n" > /entrypoint.sh
+RUN echo "#!/bin/sh\n" \
+         "set -e\n" \
+         "/usr/bin/envsubst < /etc/envoy/config/envoy-conf.yaml > /tmp/envoy-conf.yaml\n" \
+         "/usr/local/bin/envoy-static -c /tmp/envoy-conf.yaml \$@\n" > /entrypoint.sh
 
-RUN install -m 755 -D /entrypoint.sh /install_root/usr/local/bin/entrypoint.sh
-RUN install -D /usr/bin/envsubst /install_root/usr/bin/envsubst
+RUN install -m 755 -D /entrypoint.sh /tmp/install_root/usr/local/bin/entrypoint.sh
+RUN install -D /usr/bin/envsubst /tmp/install_root/usr/bin/envsubst
 
-FROM scratch as final
-COPY --from=builder /install_root /
+FROM ubuntu:focal as final
+COPY --from=builder /tmp/install_root /
 
 ENV PATH=/usr/local/bin
 ENV QAT_SECTION_NAME SHIM
-ENV POLL_DELAY 2000000
+ENV POLL_DELAY 0.005s
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/deployments/boringssl-envoy-deployment.yaml
+++ b/deployments/boringssl-envoy-deployment.yaml
@@ -42,10 +42,10 @@ data:
                   private_key_provider:
                     provider_name: qat
                     typed_config:
-                      "@type": "type.googleapis.com/envoy.extensions.private_key_operations_providers.qat.v3.QatPrivateKeyMethodConfig"
+                      "@type": "type.googleapis.com/envoy.extensions.private_key_providers.qat.v3alpha.QatPrivateKeyMethodConfig"
                       section_name: ${QAT_SECTION_NAME}
                       poll_delay: ${POLL_DELAY}
-                      private_key: "/etc/envoy/tls/tls.key"
+                      private_key: { filename: "/etc/envoy/tls/tls.key" }
           filters:
           - name: envoy.http_connection_manager
             typed_config:
@@ -62,7 +62,7 @@ data:
                   - match: { prefix: / }
                     direct_response: { status: 200 }
               http_filters:
-              - name: envoy.router
+              - name: envoy.filters.http.router
                 typed_config: {}
     admin:
       access_log_path: "/dev/null"

--- a/deployments/nginx-behind-envoy-deployment-no-qat.yaml
+++ b/deployments/nginx-behind-envoy-deployment-no-qat.yaml
@@ -49,7 +49,7 @@ data:
                     route:
                       cluster: local_service
               http_filters:
-              - name: envoy.router
+              - name: envoy.filters.http.router
                 config: {}
       clusters:
       - name: local_service

--- a/deployments/nginx-behind-envoy-deployment.yaml
+++ b/deployments/nginx-behind-envoy-deployment.yaml
@@ -34,10 +34,10 @@ data:
                 private_key_provider:
                   provider_name: qat
                   typed_config:
-                    "@type": "type.googleapis.com/envoy.extensions.private_key_operations_providers.qat.v3.QatPrivateKeyMethodConfig"
+                    "@type": "type.googleapis.com/envoy.extensions.private_key_providers.qat.v3alpha.QatPrivateKeyMethodConfig"
                     section_name: ${QAT_SECTION_NAME}
                     poll_delay: ${POLL_DELAY}
-                    private_key: "/etc/envoy/tls/tls.key"
+                    private_key: { filename: "/etc/envoy/tls/tls.key" }
           filters:
           - name: envoy.http_connection_manager
             config:
@@ -55,7 +55,7 @@ data:
                     route:
                       cluster: local_service
               http_filters:
-              - name: envoy.router
+              - name: envoy.filters.http.router
                 config: {}
       clusters:
       - name: local_service

--- a/examples/boringssl-envoy-conf.yaml
+++ b/examples/boringssl-envoy-conf.yaml
@@ -15,10 +15,10 @@ static_resources:
               private_key_provider:
                 provider_name: qat
                 typed_config:
-                  "@type": "type.googleapis.com/envoy.extensions.private_key_operations_providers.qat.v3.QatPrivateKeyMethodConfig"
+                  "@type": "type.googleapis.com/envoy.extensions.private_key_providers.qat.v3alpha.QatPrivateKeyMethodConfig"
                   section_name: ${QAT_SECTION_NAME}
                   poll_delay: ${POLL_DELAY}
-                  private_key: "/etc/envoy/tls/tls.key"
+                  private_key: { filename: "/etc/envoy/tls/tls.key" }
       filters:
       - name: envoy.http_connection_manager
         typed_config:
@@ -35,7 +35,7 @@ static_resources:
               - match: { prefix: / }
                 direct_response: { status: 200 }
           http_filters:
-          - name: envoy.router
+          - name: envoy.filters.http.router
             typed_config: {}
 admin:
   access_log_path: "/dev/null"


### PR DESCRIPTION
Update Dockerfile to use the latest Envoy release (1.21) and QAT out-of-tree driver. Update the configs to match with new-style private key provider config and the changes in Envoy configuration.